### PR TITLE
Add symlink for easier docker-compose use

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,1 @@
+docker-compose-full-system.yml


### PR DESCRIPTION
This makes it convenient to run docker-compose without have to say -f
docker-compose-full-system.yml all the time. Because that's the device
we're mostly running on...