### PR TITLE
Update ip resolve script to use `ip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Docker version 20.10.8 or later is required.
 > if you like to use the old instructions with older docker, go [here](https://github.com/beamylabs/beamylabs-start/tree/16e84cbac82a740abe189a92cd1a2c1405710516)
 
 To be able to get going; that is docker pull, you need custom credentials.
-Contact us at https://www.beamylabs.com
+Contact us at <https://www.beamylabs.com>.
 
 ## Start
 
@@ -45,7 +45,7 @@ NODE_NAME=$(scripts/resolve-ip.sh eth0) docker-compose up -d
 `$(scripts/resolve-ip.sh eth0)` assumes that the interface for your main
 ethernet connection is called `eth0`. If that's not the case, you need to
 change `eth0` to the correct name. (Hint: you can can find your interface name
-using `ifconfig` or `ipconfig`).
+using `ip addr` or `ifconfig`).
 
 ## Stop
 

--- a/scripts/resolve-ip.sh
+++ b/scripts/resolve-ip.sh
@@ -12,14 +12,22 @@ if [ -z "$iface" ]; then
   exit 0
 fi
 
-found="$(ifconfig "$iface" | sed -E -n "s/^[[:space:]]*inet (([0-9]+\.){3}[0-9]+).*/\1/p")"
+# ip addr show "$iface"
+if type "ip" > /dev/null; then
+    cmd="ip addr show"
+else
+    cmd="ifconfig"
+fi
+
+
+found="$($cmd "$iface" | sed -E -n "s/^[[:space:]]*inet (([0-9]+\.){3}[0-9]+).*/\1/p")"
 case "$found" in
   ""|127.0.0.1|169.254.*)
-    ip="$defaultip"
+    ip_addr="$defaultip"
     ;;
   *)
-    ip="$found"
+    ip_addr="$found"
     ;;
 esac
 
-echo "$ip"
+echo "$ip_addr"


### PR DESCRIPTION
The script will detect if the system has the command `ip` installed. If
so, primarily use `ip` to determine the IP address of the given
interface. If `ip` is not found, use `ifconfig` just as before this
commit.

The reason for this change is that `ifconfig` has been deprecated.